### PR TITLE
Refactoring the `SighashInfo` portion of the transaction

### DIFF
--- a/zcash_test_vectors/transaction.py
+++ b/zcash_test_vectors/transaction.py
@@ -5,7 +5,6 @@ from .orchard.pallas import (
     Scalar as PallasScalar,
 )
 from .orchard.sinsemilla import group_hash as pallas_group_hash
-from .orchard_zsa.digests import NU7_TX_VERSION_BYTES
 from .sapling.generators import find_group_hash, SPENDING_KEY_BASE
 from .sapling.jubjub import (
     Fq,
@@ -509,7 +508,7 @@ class TransactionBase(object):
         ret = b''
         ret += self.header_bytes(version_bytes, version_group_id, consensus_branch_id)
         ret += self.transparent_bytes()
-        ret += self.sapling_bytes(version_bytes)
+        ret += self.sapling_bytes()
         return ret
 
     def header_bytes(self, version_bytes, version_group_id, consensus_branch_id):
@@ -539,7 +538,7 @@ class TransactionBase(object):
         # There are no such bytes for V5 transactions.
         return b''
 
-    def sapling_bytes(self, version_bytes):
+    def sapling_bytes(self):
         ret = b''
         # Sapling Transaction Fields
         has_sapling = len(self.vSpendsSapling) + len(self.vOutputsSapling) > 0
@@ -558,19 +557,19 @@ class TransactionBase(object):
             for desc in self.vSpendsSapling: # vSpendProofsSapling
                 ret += bytes(desc.proof)
             for desc in self.vSpendsSapling: # vSpendAuthSigsSapling
-                if version_bytes == NU7_TX_VERSION_BYTES:
-                    ret += write_compact_size(len(desc.spendAuthSigInfo))
-                    ret += bytes(desc.spendAuthSigInfo)
-                ret += bytes(desc.spendAuthSig)
+                ret += self.sapling_spend_auth_sig_bytes(desc)
         for desc in self.vOutputsSapling: # vOutputProofsSapling
             ret += bytes(desc.proof)
         if has_sapling:
-            if version_bytes == NU7_TX_VERSION_BYTES:
-                ret += write_compact_size(len(self.bindingSigSaplingInfo))
-                ret += bytes(self.bindingSigSaplingInfo)
-            ret += bytes(self.bindingSigSapling)
+            ret += self.sapling_binding_sig_bytes()
 
         return ret
+
+    def sapling_spend_auth_sig_bytes(self, desc):
+        return bytes(desc.spendAuthSig)
+
+    def sapling_binding_sig_bytes(self):
+        return bytes(self.bindingSigSapling)
 
 class TransactionV5(TransactionBase):
     def __init__(self, rand, consensus_branch_id):

--- a/zcash_test_vectors/transaction.py
+++ b/zcash_test_vectors/transaction.py
@@ -535,7 +535,7 @@ class TransactionBase(object):
         return ret
 
     def transparent_sighash_info_bytes(self):
-        raise NotImplementedError("The transparent_sighash_info_bytes method must be implemented.")
+        raise NotImplementedError("The transparent_sighash_info_bytes method must be implemented in the child class.")
 
     def sapling_bytes(self):
         ret = b''
@@ -565,10 +565,10 @@ class TransactionBase(object):
         return ret
 
     def sapling_spend_auth_sig_bytes(self, desc):
-        raise NotImplementedError("The sapling_spend_auth_sig_bytes method must be implemented.")
+        raise NotImplementedError("The sapling_spend_auth_sig_bytes method must be implemented in the child class.")
 
     def sapling_binding_sig_bytes(self):
-        raise NotImplementedError("The sapling_binding_sig_bytes method must be implemented.")
+        raise NotImplementedError("The sapling_binding_sig_bytes method must be implemented in the child class.")
 
 class TransactionV5(TransactionBase):
     def __init__(self, rand, consensus_branch_id):

--- a/zcash_test_vectors/transaction.py
+++ b/zcash_test_vectors/transaction.py
@@ -534,7 +534,6 @@ class TransactionBase(object):
         ret += self.transparent_sighash_info_bytes()
         return ret
 
-    # This must be defined in every child class.
     def transparent_sighash_info_bytes(self):
         raise NotImplementedError("The transparent_sighash_info_bytes method must be implemented.")
 
@@ -565,11 +564,9 @@ class TransactionBase(object):
 
         return ret
 
-    # This must be defined in every child class.
     def sapling_spend_auth_sig_bytes(self, desc):
         raise NotImplementedError("The sapling_spend_auth_sig_bytes method must be implemented.")
 
-    # This must be defined in every child class.
     def sapling_binding_sig_bytes(self):
         raise NotImplementedError("The sapling_binding_sig_bytes method must be implemented.")
 

--- a/zcash_test_vectors/transaction.py
+++ b/zcash_test_vectors/transaction.py
@@ -508,7 +508,7 @@ class TransactionBase(object):
     def to_bytes(self, version_bytes, version_group_id, consensus_branch_id):
         ret = b''
         ret += self.header_bytes(version_bytes, version_group_id, consensus_branch_id)
-        ret += self.transparent_bytes(version_bytes)
+        ret += self.transparent_bytes()
         ret += self.sapling_bytes(version_bytes)
         return ret
 
@@ -523,7 +523,7 @@ class TransactionBase(object):
 
         return ret
 
-    def transparent_bytes(self, version_bytes):
+    def transparent_bytes(self):
         ret = b''
         # Transparent Transaction Fields
         ret += write_compact_size(len(self.vin))
@@ -532,12 +532,12 @@ class TransactionBase(object):
         ret += write_compact_size(len(self.vout))
         for x in self.vout:
             ret += bytes(x)
-        if version_bytes == NU7_TX_VERSION_BYTES:
-            for sighash_info in self.vSighashInfo:
-                ret += write_compact_size(len(sighash_info))
-                ret += bytes(sighash_info)
-
+        ret += self.transparent_sighash_info_bytes()
         return ret
+
+    def transparent_sighash_info_bytes(self):
+        # There are no such bytes for V5 transactions.
+        return b''
 
     def sapling_bytes(self, version_bytes):
         ret = b''

--- a/zcash_test_vectors/transaction.py
+++ b/zcash_test_vectors/transaction.py
@@ -534,9 +534,9 @@ class TransactionBase(object):
         ret += self.transparent_sighash_info_bytes()
         return ret
 
+    # This must be defined in every child class.
     def transparent_sighash_info_bytes(self):
-        # There are no such bytes for V5 transactions.
-        return b''
+        raise NotImplementedError("The transparent_sighash_info_bytes method must be implemented.")
 
     def sapling_bytes(self):
         ret = b''
@@ -565,11 +565,13 @@ class TransactionBase(object):
 
         return ret
 
+    # This must be defined in every child class.
     def sapling_spend_auth_sig_bytes(self, desc):
-        return bytes(desc.spendAuthSig)
+        raise NotImplementedError("The sapling_spend_auth_sig_bytes method must be implemented.")
 
+    # This must be defined in every child class.
     def sapling_binding_sig_bytes(self):
-        return bytes(self.bindingSigSapling)
+        raise NotImplementedError("The sapling_binding_sig_bytes method must be implemented.")
 
 class TransactionV5(TransactionBase):
     def __init__(self, rand, consensus_branch_id):
@@ -595,6 +597,16 @@ class TransactionV5(TransactionBase):
     @staticmethod
     def version_bytes():
         return NU5_TX_VERSION_BYTES
+
+    def transparent_sighash_info_bytes(self):
+        # There are no such bytes for V5 transactions.
+        return b''
+
+    def sapling_spend_auth_sig_bytes(self, desc):
+        return bytes(desc.spendAuthSig)
+
+    def sapling_binding_sig_bytes(self):
+        return bytes(self.bindingSigSapling)
 
     def __bytes__(self):
         ret = b''

--- a/zcash_test_vectors/transaction_v6.py
+++ b/zcash_test_vectors/transaction_v6.py
@@ -205,6 +205,20 @@ class TransactionV6(TransactionBase):
             ret += bytes(sighash_info)
         return ret
 
+    def sapling_spend_auth_sig_bytes(self, desc):
+        ret = b''
+        ret += write_compact_size(len(desc.spendAuthSigInfo))
+        ret += bytes(desc.spendAuthSigInfo)
+        ret += bytes(desc.spendAuthSig)
+        return ret
+
+    def sapling_binding_sig_bytes(self):
+        ret = b''
+        ret += write_compact_size(len(self.bindingSigSaplingInfo))
+        ret += bytes(self.bindingSigSaplingInfo)
+        ret += bytes(self.bindingSigSapling)
+        return ret
+
     def issuance_field_bytes(self):
         ret = b''
         ret += write_compact_size(len(self.issuer))

--- a/zcash_test_vectors/transaction_v6.py
+++ b/zcash_test_vectors/transaction_v6.py
@@ -198,6 +198,13 @@ class TransactionV6(TransactionBase):
         ret += struct.pack('<Q', self.zip233Amount)
         return ret
 
+    def transparent_sighash_info_bytes(self):
+        ret = b''
+        for sighash_info in self.vSighashInfo:
+            ret += write_compact_size(len(sighash_info))
+            ret += bytes(sighash_info)
+        return ret
+
     def issuance_field_bytes(self):
         ret = b''
         ret += write_compact_size(len(self.issuer))


### PR DESCRIPTION
This PR refactors the portions of the `TransactionBase` class so that it does not need to use the `version_group_id` to decide behaviour - the way it behaves is decided by redefinition of the added functions in the child classes (aka `TransactionV5` and `TransactionV6`).

This refactor does not affect the generated test vectors.