### PR TITLE
Move canonical proof sizing into ActionGroupDescription

### DIFF
--- a/zcash_test_vectors/transaction_v6.py
+++ b/zcash_test_vectors/transaction_v6.py
@@ -24,6 +24,7 @@ ZC_ORCHARD_ZSA_ENCCIPHERTEXT_SIZE = ZC_ORCHARD_ZSA_ENCPLAINTEXT_SIZE + NOTEENCRY
 # SighashInfo V0
 SIGHASH_INFO_V0 = [0] + [] # sighashInfo = [sighashVersion] || associatedData
 
+# Must match Proof::expected_proof_size for OrchardZSA in QED-it/orchard.
 ORCHARD_ZSA_BASE_PROOF_SIZE = 2848
 ORCHARD_ZSA_PER_ACTION_PROOF_SIZE = 2272
 

--- a/zcash_test_vectors/transaction_v6.py
+++ b/zcash_test_vectors/transaction_v6.py
@@ -157,6 +157,10 @@ class TransactionV6(TransactionBase):
 
         # All Transparent, Sapling, and part of the Orchard Transaction Fields are initialized in the super class.
         super().__init__(rand, have_orchard_zsa)
+        if have_orchard_zsa:
+            # The base class draws proofsOrchard only to keep the rand stream stable;
+            # V6 proofs live per Action Group, so drop the stale attribute.
+            del self.proofsOrchard
         self.vSighashInfo = [sighash_info] * len(self.vin)
         for desc in self.vSpendsSapling:
             desc.spendAuthSigInfo = sighash_info

--- a/zcash_test_vectors/transaction_v6.py
+++ b/zcash_test_vectors/transaction_v6.py
@@ -95,7 +95,7 @@ class IssueNoteDescription(object):
 
 
 class ActionGroupDescription(object):
-    def __init__(self, rand, anchor_orchard, proofs_orchard, is_coinbase, have_burn, sighash_info):
+    def __init__(self, rand, anchor_orchard, is_coinbase, have_burn, sighash_info):
         self.vActionsOrchard = []
         # There must always be a non-zero number of Action Descriptions in an Action Group.
         for _ in range(rand.u8() % 4 + 1):
@@ -108,7 +108,6 @@ class ActionGroupDescription(object):
             # set enableSpendsOrchard = 0
             self.flagsOrchard &= 2
         self.anchorOrchard = anchor_orchard
-        self.proofsOrchard = proofs_orchard
         self.nAGExpiryHeight = 0
 
         # OrchardZSA Burn Fields
@@ -116,6 +115,8 @@ class ActionGroupDescription(object):
         if have_burn:
             for _ in range(rand.u8() % 5):
                 self.vAssetBurnOrchardZSA.append(AssetBurnDescription(rand))
+
+        self.proofsOrchard = rand.b(orchard_zsa_proof_size(len(self.vActionsOrchard)))
 
 
     def __bytes__(self):
@@ -173,9 +174,7 @@ class TransactionV6(TransactionBase):
         self.vActionGroupsOrchard = []
         if have_orchard_zsa:
             # For NU7 we have a maximum of one Action Group.
-            action_group = ActionGroupDescription(rand, self.anchorOrchard, self.proofsOrchard, self.is_coinbase(), have_burn, sighash_info)
-            action_group.proofsOrchard = rand.b(orchard_zsa_proof_size(len(action_group.vActionsOrchard)))
-            self.vActionGroupsOrchard.append(action_group)
+            self.vActionGroupsOrchard.append(ActionGroupDescription(rand, self.anchorOrchard, self.is_coinbase(), have_burn, sighash_info))
 
         # OrchardZSA Issuance Fields
         self.vIssueActions = []


### PR DESCRIPTION
- Generate the canonical-size proof inside ActionGroupDescription.__init__ and drop the now-unused proofs_orchard constructor parameter, so the size invariant is enforced by the class rather than each call site.
- Delete the stale transaction-level proofsOrchard on V6 (the base class draws it only for rand-stream stability), so accidental reads fail loudly instead of using never-serialized bytes.